### PR TITLE
msc: fix memory leak when block device open fail

### DIFF
--- a/msc.c
+++ b/msc.c
@@ -1843,6 +1843,7 @@ err3:
 	close(msc->fd);
 
 err2:
+	free(msc->txbuf);
 	free(msc->rxbuf);
 
 err1:


### PR DESCRIPTION
When block device open fail, there is a memory leak about msc->txbuf.
So add free(msc->txbuf) if block device open fail case.

Signed-off-by: Jaejoong Kim <climbbb.kim@gmail.com>