### PR TITLE
Few fixes and updates against cleware

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,9 +34,11 @@ PKG_CHECK_MODULES([libusb], [libusb-1.0])
 PKG_CHECK_MODULES([ssl], [openssl])
 
 # hidapi
-PKG_CHECK_MODULES([hid], [hidapi], [], [
-  PKG_CHECK_MODULES([hid], [hidapi-hidraw], [], [
-    PKG_CHECK_MODULES([hid], [hidapi-libusb])])])
+AC_ARG_WITH([hidapi], [AS_HELP_STRING([--with-hidapi], [choose hidapi])],
+  [PKG_CHECK_MODULES([hid], [$withval], [], [])],
+  [PKG_CHECK_MODULES([hid], [hidapi], [], [
+    PKG_CHECK_MODULES([hid], [hidapi-hidraw], [], [
+      PKG_CHECK_MODULES([hid], [hidapi-libusb])])])])
 
 # libpthread
 m4_include([m4/ax_pthread.m4])

--- a/src/cleware.c
+++ b/src/cleware.c
@@ -359,6 +359,7 @@ int main(int argc, char *argv[])
 	}
 
 out3:
+	hid_close(c->handle);
 	free(c);
 
 out2:

--- a/src/cleware.c
+++ b/src/cleware.c
@@ -203,7 +203,7 @@ static int cleware_get_switch(struct cleware *c, unsigned int port)
 	if (c->inverted)
 		state = !state;
 
-	fprintf(stdout, "%d: %s\n", port, state ? "ON" : "OFF");
+	fprintf(stdout, "%d: %s\n", port + 1, state ? "ON" : "OFF");
 
 	return 0;
 }

--- a/src/cleware.c
+++ b/src/cleware.c
@@ -280,7 +280,10 @@ int main(int argc, char *argv[])
 			break;
 		case 'p':
 			port = atoi(optarg);
-			break;
+			if (port >= 1)
+				break;
+			fprintf(stderr, "invalid port number\n");
+			goto out1;
 		case 'r':
 			read = 1;
 			break;


### PR DESCRIPTION
* Fix exit when libusb backend is in use
* Fix inconsistency with port numbering when reading and printing
* Don't allow to enter port numbers less than 1
* Allow to choose the HID API backend